### PR TITLE
#12 named column lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ fn main() -> Result<(), oracledb::Error> {
     let row = conn.query_row("select user from dual", &[])?;
     // using positional
     let user: String = row.get(0)?;
-    //using named lookup
-    let user: String = row.get("user");
+    // using named lookup
+    let user: String = row.get("USER")?;
     // perform query that returns multiple rows with a bind parameter
     let cursor = conn.query(
         "select ename, sal, comm from emp where deptno = :1", &[&30]

--- a/README.md
+++ b/README.md
@@ -63,8 +63,10 @@ fn main() -> Result<(), oracledb::Error> {
 
     // perform simple query that returns a single row with no bind parameters
     let row = conn.query_row("select user from dual", &[])?;
+    // using positional
     let user: String = row.get(0)?;
-
+    //using named lookup
+    let user: String = row.get("user");
     // perform query that returns multiple rows with a bind parameter
     let cursor = conn.query(
         "select ename, sal, comm from emp where deptno = :1", &[&30]

--- a/src/column_index.rs
+++ b/src/column_index.rs
@@ -1,0 +1,63 @@
+//-----------------------------------------------------------------------------
+// Copyright (c) 2026, Oracle and/or its affiliates.
+//
+// This software is dual-licensed to you under the Universal Permissive License
+// (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl and Apache License
+// 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose
+// either license.
+//
+// If you elect to accept the software under the Apache License, Version 2.0,
+// the following applies:
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-----------------------------------------------------------------------------
+
+//-----------------------------------------------------------------------------
+// column_index.rs
+//
+// Defines the trait for resolving column positions by index or name.
+//-----------------------------------------------------------------------------
+
+use crate::{Error, Row};
+
+/// A trait for types that can be used to index columns in a [`Row`].
+///
+/// Both numeric indices (`usize`) and column names (`&str`) implement this trait.
+pub trait ColumnIndex {
+    /// Resolves the column position within the given row.
+    fn resolve(&self, row: &Row) -> Result<usize, Error>;
+}
+
+impl ColumnIndex for usize {
+    fn resolve(&self, row: &Row) -> Result<usize, Error> {
+        if *self < row.column_values.len() {
+            Ok(*self)
+        } else {
+            Err(Error::invalid_column_index(*self))
+        }
+    }
+}
+
+impl ColumnIndex for &str {
+    fn resolve(&self, row: &Row) -> Result<usize, Error> {
+        if let Some(metadata) = &row.metadata {
+            if let Some(index) = metadata
+                .iter()
+                .position(|col| col.name().eq_ignore_ascii_case(self))
+            {
+                return Ok(index);
+            }
+        }
+        Err(Error::invalid_column_name(self))
+    }
+}

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -51,7 +51,7 @@ pub struct Cursor {
     rows: VecDeque<RowData>,
     last_row: Option<RowData>,
     end_of_fetch: bool,
-	metadata: Option<Arc<Vec<Metadata>>>
+    metadata: Option<Arc<Vec<Metadata>>>,
 }
 
 impl Cursor {
@@ -101,13 +101,13 @@ impl Cursor {
 
     /// Creates a new cursor.
     pub(crate) fn new(statement_holder: StatementHolder) -> Self {
-	    let metadata = Some(Arc::new(statement_holder.out_metadata().clone()));
+        let metadata = Some(Arc::new(statement_holder.out_metadata().clone()));
         Self {
             statement_holder,
             rows: VecDeque::<RowData>::new(),
             last_row: None,
             end_of_fetch: false,
-	        metadata
+            metadata,
         }
     }
 

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -29,7 +29,7 @@
 //-----------------------------------------------------------------------------
 
 use std::collections::VecDeque;
-
+use std::sync::Arc;
 #[cfg(feature = "arrow")]
 use crate::bind_params::BindParameters;
 use crate::client::Client;
@@ -51,6 +51,7 @@ pub struct Cursor {
     rows: VecDeque<RowData>,
     last_row: Option<RowData>,
     end_of_fetch: bool,
+	metadata: Option<Arc<Vec<Metadata>>>
 }
 
 impl Cursor {
@@ -100,11 +101,13 @@ impl Cursor {
 
     /// Creates a new cursor.
     pub(crate) fn new(statement_holder: StatementHolder) -> Self {
+	    let metadata = Some(Arc::new(statement_holder.out_metadata().clone()));
         Self {
             statement_holder,
             rows: VecDeque::<RowData>::new(),
             last_row: None,
             end_of_fetch: false,
+	        metadata
         }
     }
 
@@ -141,7 +144,7 @@ impl Iterator for Cursor {
             if self.rows.is_empty() {
                 self.last_row = Some(row.clone());
             }
-            Some(Ok(Row::new(row)))
+            Some(Ok(Row::new(row, self.metadata.clone())))
         } else {
             None
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -222,9 +222,9 @@ impl fmt::Display for Error {
             ErrorKind::InvalidColumnIndex(index) => {
                 write!(fmt, "invalid column index {} (zero-based)", index)?
             }
-	        ErrorKind::InvalidColumnName(name) => {
-		        write!(fmt, "invalid column name \"{}\"", name)?
-	        }
+            ErrorKind::InvalidColumnName(name) => {
+                write!(fmt, "invalid column name \"{}\"", name)?
+            }
             ErrorKind::InvalidConnectString(connect_string, reason) => {
                 write!(fmt, "invalid connect string: {connect_string}: {reason}")?
             }
@@ -496,9 +496,9 @@ impl Error {
         Error::new(ErrorKind::InvalidColumnIndex(index), None)
     }
 
-	pub(crate) fn invalid_column_name(name: &str) -> Error {
-		Error::new(ErrorKind::InvalidColumnName(name.to_string()), None)
-	}
+    pub(crate) fn invalid_column_name(name: &str) -> Error {
+        Error::new(ErrorKind::InvalidColumnName(name.to_string()), None)
+    }
 
     pub(crate) fn invalid_connect_string(
         connect_string: &str,

--- a/src/error.rs
+++ b/src/error.rs
@@ -50,6 +50,7 @@ pub enum ErrorKind {
     IntegerTooLarge(usize, usize),
     InvalidBindName(String),
     InvalidColumnIndex(usize),
+	InvalidColumnName(String),
     InvalidConnectString(String, String),
     InvalidDescriptorNode(String, String),
     InvalidEncodedString,
@@ -221,6 +222,9 @@ impl fmt::Display for Error {
             ErrorKind::InvalidColumnIndex(index) => {
                 write!(fmt, "invalid column index {} (zero-based)", index)?
             }
+	        ErrorKind::InvalidColumnName(name) => {
+		        write!(fmt, "invalid column name \"{}\"", name)?
+	        }
             ErrorKind::InvalidConnectString(connect_string, reason) => {
                 write!(fmt, "invalid connect string: {connect_string}: {reason}")?
             }
@@ -491,6 +495,10 @@ impl Error {
     pub(crate) fn invalid_column_index(index: usize) -> Error {
         Error::new(ErrorKind::InvalidColumnIndex(index), None)
     }
+
+	pub(crate) fn invalid_column_name(name: &str) -> Error {
+		Error::new(ErrorKind::InvalidColumnName(name.to_string()), None)
+	}
 
     pub(crate) fn invalid_connect_string(
         connect_string: &str,

--- a/src/exec_result.rs
+++ b/src/exec_result.rs
@@ -60,7 +60,7 @@ impl ExecResult {
         if let Some(returned_data) = self.returned_data.take() {
             let mut rows = Vec::<Row>::with_capacity(returned_data.len());
             for column_values in returned_data {
-                rows.push(Row::new(column_values));
+                rows.push(Row::new(column_values, None));
             }
             rows
         } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,6 +82,7 @@ pub use crate::lob::Lob;
 pub use crate::metadata::Metadata;
 pub use crate::ora_version::OracleVersion;
 pub use crate::pool::Pool;
+pub use crate::column_index::ColumnIndex;
 pub use crate::row::Row;
 pub use crate::statement::Statement;
 pub use crate::vector::SparseVector;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,6 +66,7 @@ mod transport;
 mod utils;
 mod vector;
 mod write_buffer;
+mod column_index;
 
 // public structs
 pub use crate::config::Config;

--- a/src/row.rs
+++ b/src/row.rs
@@ -75,7 +75,7 @@ impl Row {
         <T>::from_db_value(ColumnData::Borrowed(value_opt))
     }
 
-    /// Returns the array at the given column index as a vector.
+    /// Returns the array at the given column index or name as a vector.
     pub fn get_array<'a, T>(
         &'a self,
         index: impl ColumnIndex,
@@ -91,7 +91,7 @@ impl Row {
         <T>::from_db_value_array(ColumnData::Borrowed(value_opt))
     }
 
-    /// Returns the value at the given column index, converted to the requested
+    /// Returns the value at the given column index or name, converted to the requested
     /// type. Ownership of the data that was stored in the row at the given
     /// column index is transferred to the caller. If this is attempted with a
     /// reference type, an error will take place.
@@ -107,7 +107,7 @@ impl Row {
         <T>::from_db_value(ColumnData::Owned(value_opt.take()))
     }
 
-    /// Returns the array at the given column index as a vector.
+    /// Returns the array at the given column index or name as a vector.
     pub fn take_array<'a, T>(
         &'a mut self,
         index: impl ColumnIndex,

--- a/src/row.rs
+++ b/src/row.rs
@@ -48,7 +48,7 @@ pub struct Row {
 }
 
 impl Row {
-    /// Creates a new row from the set of column values.
+    /// Creates a new row from the set of column values and metadata.
     pub(crate) fn new(
         column_values: RowData,
         metadata: Option<Arc<Vec<Metadata>>>,
@@ -59,7 +59,7 @@ impl Row {
         }
     }
 
-    /// Returns the value at the given column index, converted to the requested
+    /// Returns the value at the given column index or name, converted to the requested
     /// type. If a reference type is supplied, a reference is provided to the
     /// internal data, if possible. If an owned type is supplied, a copy of
     /// the internal data is made.

--- a/src/row.rs
+++ b/src/row.rs
@@ -28,8 +28,12 @@
 // Defines the structure containing row data.
 //-----------------------------------------------------------------------------
 
+use std::sync::Arc;
+
+use crate::column_index::ColumnIndex;
 use crate::db_value::{DbValue, FromDbValue};
 use crate::error::Error;
+use crate::metadata::Metadata;
 
 pub(crate) type RowData = Vec<Option<DbValue>>;
 
@@ -39,39 +43,51 @@ pub enum ColumnData<'a> {
 }
 
 pub struct Row {
-    column_values: RowData,
+    pub(crate) column_values: RowData,
+    pub(crate) metadata: Option<Arc<Vec<Metadata>>>,
 }
 
 impl Row {
     /// Creates a new row from the set of column values.
-    pub(crate) fn new(column_values: RowData) -> Row {
-        Row { column_values }
+    pub(crate) fn new(
+        column_values: RowData,
+        metadata: Option<Arc<Vec<Metadata>>>,
+    ) -> Row {
+        Row {
+            column_values,
+            metadata,
+        }
     }
 
     /// Returns the value at the given column index, converted to the requested
     /// type. If a reference type is supplied, a reference is provided to the
     /// internal data, if possible. If an owned type is supplied, a copy of
     /// the internal data is made.
-    pub fn get<'a, T>(&'a self, index: usize) -> Result<T, Error>
+    pub fn get<'a, T>(&'a self, index: impl ColumnIndex) -> Result<T, Error>
     where
         T: FromDbValue<'a>,
     {
+        let i = index.resolve(self)?;
         let value_opt = self
             .column_values
-            .get(index)
-            .ok_or(Error::invalid_column_index(index))?;
+            .get(i)
+            .ok_or(Error::invalid_column_index(i))?;
         <T>::from_db_value(ColumnData::Borrowed(value_opt))
     }
 
     /// Returns the array at the given column index as a vector.
-    pub fn get_array<'a, T>(&'a self, index: usize) -> Result<Vec<T>, Error>
+    pub fn get_array<'a, T>(
+        &'a self,
+        index: impl ColumnIndex,
+    ) -> Result<Vec<T>, Error>
     where
         T: FromDbValue<'a>,
     {
+        let i = index.resolve(self)?;
         let value_opt = self
             .column_values
-            .get(index)
-            .ok_or(Error::invalid_column_index(index))?;
+            .get(i)
+            .ok_or(Error::invalid_column_index(i))?;
         <T>::from_db_value_array(ColumnData::Borrowed(value_opt))
     }
 
@@ -79,29 +95,31 @@ impl Row {
     /// type. Ownership of the data that was stored in the row at the given
     /// column index is transferred to the caller. If this is attempted with a
     /// reference type, an error will take place.
-    pub fn take<'a, T>(&'a mut self, index: usize) -> Result<T, Error>
+    pub fn take<'a, T>(&'a mut self, index: impl ColumnIndex) -> Result<T, Error>
     where
         T: FromDbValue<'a>,
     {
+        let i = index.resolve(self)?;
         let value_opt = self
             .column_values
-            .get_mut(index)
-            .ok_or(Error::invalid_column_index(index))?;
+            .get_mut(i)
+            .ok_or(Error::invalid_column_index(i))?;
         <T>::from_db_value(ColumnData::Owned(value_opt.take()))
     }
 
     /// Returns the array at the given column index as a vector.
     pub fn take_array<'a, T>(
         &'a mut self,
-        index: usize,
+        index: impl ColumnIndex,
     ) -> Result<Vec<T>, Error>
     where
         T: FromDbValue<'a>,
     {
+        let i = index.resolve(self)?;
         let value_opt = self
             .column_values
-            .get_mut(index)
-            .ok_or(Error::invalid_column_index(index))?;
+            .get_mut(i)
+            .ok_or(Error::invalid_column_index(i))?;
         <T>::from_db_value_array(ColumnData::Owned(value_opt.take()))
     }
 }

--- a/tests/test_2700_execution.rs
+++ b/tests/test_2700_execution.rs
@@ -518,14 +518,11 @@ fn test_2718(conn: oracledb::Connection) -> Result<(), oracledb::Error> {
         "select cursor(select level from dual connect by level <= 3) as nested_cur from dual",
         &[],
     )?;
-    let mut cursor: oracledb::Cursor = row.take("nested_cur")?;
-    let mut count = 0;
-    for child_row in cursor.by_ref() {
-        let child_row = child_row?;
-        count += 1;
-        assert_eq!(child_row.get::<i32>(0)?, count);
-    }
-    assert_eq!(count, 3);
+    let cursor: oracledb::Cursor = row.take("nested_cur")?;
+    let values: Vec<i32> = cursor
+        .map(|row| row?.get("level"))
+        .collect::<Result<Vec<_>, _>>()?;
+    assert_eq!(values, vec![1, 2, 3]);
 
     Ok(())
 }

--- a/tests/test_2700_execution.rs
+++ b/tests/test_2700_execution.rs
@@ -479,35 +479,53 @@ fn test_2717(conn: oracledb::Connection) -> Result<(), oracledb::Error> {
 }
 
 #[rstest]
-/// Tests named column lookup on Row::get().
+/// Tests named column lookup on Row::get() and Row::take().
 fn test_2718(conn: oracledb::Connection) -> Result<(), oracledb::Error> {
-	let row = conn.query_row(
-		"select 'test_2718' as test_name, 2718 as test_number from dual",
-		&[],
-	)?;
-	// existing behavior (positional)
-	assert_eq!(row.get(0)?, "test_2718");
-	assert_eq!(row.get(1)?, 2718);
+    let row = conn.query_row(
+        "select 'test_2718' as test_name, 2718 as test_number from dual",
+        &[],
+    )?;
+    // existing behavior (positional)
+    assert_eq!(row.get::<String>(0)?, "test_2718");
+    assert_eq!(row.get::<i32>(1)?, 2718);
 
-	// named lookup
-	assert_eq!(row.get("test_name")?, "test_2718");
-	assert_eq!(row.get("test_number")?, 2718);
+    // named lookup
+    assert_eq!(row.get::<String>("test_name")?, "test_2718");
+    assert_eq!(row.get::<i32>("test_number")?, 2718);
 
-	// case-insensitive named lookup
-	assert_eq!(row.get("test_Name")?, "test_2718");
-	assert_eq!(row.get("test_Number")?, 2718);
-	assert_eq!(row.get("TEST_NAME")?, "test_2718");
-	assert_eq!(row.get("TEST_NUMBER")?, 2718);
+    // case-insensitive named lookup
+    assert_eq!(row.get::<String>("test_Name")?, "test_2718");
+    assert_eq!(row.get::<i32>("test_Number")?, 2718);
+    assert_eq!(row.get::<String>("TEST_NAME")?, "test_2718");
+    assert_eq!(row.get::<i32>("TEST_NUMBER")?, 2718);
 
-	// Non-existing
-	assert_eq!(row.get("NO-EXISTS").is_err(), true );
+    // out-of-bounds positional index
+    assert!(row.get::<String>(99).is_err());
 
-	let row = conn.query_row(
-		"select 'first' as name, 'second' as name from dual",
-		&[],
-	)?;
-	assert_eq!(row.get("name")?, "first");
-	assert_ne!(row.get("name")?, "second");
+    // non-existing column name
+    assert!(row.get::<String>("NO-EXISTS").is_err());
 
-	Ok(())
+    // duplicate column names (first match wins)
+    let row = conn.query_row(
+        "select 'first' as name, 'second' as name from dual",
+        &[],
+    )?;
+    assert_eq!(row.get::<String>("name")?, "first");
+    assert_ne!(row.get::<String>("name")?, "second");
+
+    // named lookup on nested cursor with Row::take()
+    let mut row = conn.query_row(
+        "select cursor(select level from dual connect by level <= 3) as nested_cur from dual",
+        &[],
+    )?;
+    let mut cursor: oracledb::Cursor = row.take("nested_cur")?;
+    let mut count = 0;
+    for child_row in cursor.by_ref() {
+        let child_row = child_row?;
+        count += 1;
+        assert_eq!(child_row.get::<i32>(0)?, count);
+    }
+    assert_eq!(count, 3);
+
+    Ok(())
 }

--- a/tests/test_2700_execution.rs
+++ b/tests/test_2700_execution.rs
@@ -477,3 +477,37 @@ fn test_2717(conn: oracledb::Connection) -> Result<(), oracledb::Error> {
     assert!(values.is_empty());
     Ok(())
 }
+
+#[rstest]
+/// Tests named column lookup on Row::get().
+fn test_2718(conn: oracledb::Connection) -> Result<(), oracledb::Error> {
+	let row = conn.query_row(
+		"select 'test_2718' as test_name, 2718 as test_number from dual",
+		&[],
+	)?;
+	// existing behavior (positional)
+	assert_eq!(row.get(0)?, "test_2718");
+	assert_eq!(row.get(1)?, 2718);
+
+	// named lookup
+	assert_eq!(row.get("test_name")?, "test_2718");
+	assert_eq!(row.get("test_number")?, 2718);
+
+	// case-insensitive named lookup
+	assert_eq!(row.get("test_Name")?, "test_2718");
+	assert_eq!(row.get("test_Number")?, 2718);
+	assert_eq!(row.get("TEST_NAME")?, "test_2718");
+	assert_eq!(row.get("TEST_NUMBER")?, 2718);
+
+	// Non-existing
+	assert_eq!(row.get("NO-EXISTS").is_err(), true );
+
+	let row = conn.query_row(
+		"select 'first' as name, 'second' as name from dual",
+		&[],
+	)?;
+	assert_eq!(row.get("name")?, "first");
+	assert_ne!(row.get("name")?, "second");
+
+	Ok(())
+}


### PR DESCRIPTION
### Description

Fixes #12

This PR introduces named column lookup on `Row::get()`, `Row::get_array()`, and `Row::get_cursor()`, allowing column retrieval by name (e.g. `row.get("USER_ID")`) in addition to existing positional indexing (e.g. `row.get(0)`).

### Summary of Changes

1. **`ColumnIndex` Trait (`src/column_index.rs`)**:
   - Added `ColumnIndex` trait implemented for both `usize` (positional) and `&str` (column name).
   - Exported `ColumnIndex` in `src/lib.rs` for public use.
   - Column name resolution uses `.iter().position()` with `eq_ignore_ascii_case()` to support case-insensitive matching (Oracle uppercase conventions) with zero heap allocations.
   - For duplicate column names in a result set, the first matching column takes precedence (matching `python-oracledb` behavior).

2. **`Row` & `Cursor` Integration (`src/row.rs`, `src/cursor.rs`)**:
   - `Row` now holds an `Option<Arc<Vec<Metadata>>>` alongside `column_values`.
   - `Cursor` constructs the `Arc<Vec<Metadata>>` once at creation time and shares it across all yielded rows, ensuring zero vector cloning and zero allocations per row during iteration.
   - `Row::get`, `Row::get_array`, and `Row::get_cursor` updated to accept `impl ColumnIndex`. Existing positional calls remain backwards-compatible.

3. **Error Handling (`src/error.rs`)**:
   - Added `ErrorKind::InvalidColumnName(String)` for non-existent column lookups.

4. **Testing (`tests/test_2700_execution.rs`)**:
   - Added `test_2718` covering:
     - Positional access (`usize`)
     - Named access (`&str`) with uppercase, lowercase, and mixed case
     - Error handling on non-existent column names and out-of-bounds indices
     - Duplicate column name shadowing behavior

5. **Documentation (`README.md`)**:
   - Added named lookup example alongside positional query usage.

### How to Validate

Run the integration test suite:
```bash
cargo test --test test_2700_execution
```
### Downstream Validation

Tested and validated in [Rc-Bank](https://github.com/frogdevops/Rc-Bank.git):
- Confirmed named column lookups on real queries (`user_id`, `created_at`, `updated_at`).
- Verified case-insensitivity and type conversion into chrono timestamps.